### PR TITLE
Fix no help text showing when option's default is NA

### DIFF
--- a/R/optparse.R
+++ b/R/optparse.R
@@ -262,6 +262,7 @@ print_help <- function(object) {
         cat("\n\t\t")
         default <- as.character(option@default)
         default_str <- ifelse(length(default), default, "NULL")
+        if(is.na(default_str)) { default_str <- "NA" }
         cat(sub("%default", default_str, option@help))
         cat("\n\n")
     }


### PR DESCRIPTION
Hi Trevor,

Thank you for great port of optparse to R! I've realized today that when defining an option with a default value of `NA`, the help message printed by the `-h` switch will not show a help text for this option. Consider e.g. the following minimal example:

```
#!/usr/bin/env Rscript
library(optparse)

option_list <- list(
    make_option(c("-o", "--long-option"), dest="my_option", default=NA, help="An option [default: %default]")
)
opt <- parse_args(OptionParser(option_list = option_list))

print(opt)
```

Running this from the command line I get:

```
$ ./example.R -h
Usage: ./example.R [options]


Options:
    -o LONG-OPTION, --long-option=LONG-OPTION
        NA

    -h, --help
        Show this help message and exit
```

I've traced this to the [sub call](https://github.com/trevorld/optparse/blob/master/R/optparse.R#L265) for replacing the `%default` variable in the help text. When the replacement is `NA`, the whole returned string will be `NA` (the constant, not the string!). The replacement is `NA` because `as.character(NA) = NA`, not `"NA"` as expected.

The pull request adds a check for `NA` in the `default_str` to check for this corner case and replace `NA` with `"NA"` so that the help text can be correctly formatted.

Best,
Stefan
